### PR TITLE
package.json: add 'main' for browserify and webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "color-difference",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Color difference calculator",
   "scripts": {
     "test": "make test"
   },
+  "main": "./lib",
   "bin": {
     "color-difference": "./bin/color-difference"
   },


### PR DESCRIPTION
As @Pomax said, this module can't be used in browserify (or webpack). Adding a main property to package.json that points to `./lib` fixes that.
